### PR TITLE
Fix server codec support checks. Add AV1 support

### DIFF
--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -302,6 +302,7 @@ NvHTTP.prototype = {
     this.serverMajorVersion = parseInt(this.appVersion.substring(0, 1), 10);
     this.serverUid = $root.find('uniqueid').text().trim();
     this.hostname = $root.find('hostname').text().trim();
+    this.serverCodecSupportMode = $root.find('ServerCodecModeSupport').text().trim();
 
     var externIP = $root.find('ExternalIP').text().trim();
     if (externIP) {

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -74,6 +74,10 @@
               <li class="mdl-menu__item" data-value=0x0001>H264</li>
               <li class="mdl-menu__item" data-value=0x0100>HEVC</li>
               <li class="mdl-menu__item" data-value=0x0200>HEVC Main10</li>
+              <li class="mdl-menu__item" data-value=0x1000>AV1</li>
+              <li class="mdl-menu__item" data-value=0x2000>AV1 Main10</li>
+
+
             </ul>
             <div id="codecVideoMenuTooltip" class="mdl-tooltip" for="codecVideoMenu">Video Codec</div>
           </div>

--- a/wasm/main.cpp
+++ b/wasm/main.cpp
@@ -177,7 +177,7 @@ MessageResult MoonlightInstance::StartStream(
 std::string host, std::string width, std::string height, std::string fps,
 std::string bitrate, std::string rikey, std::string rikeyid,
 std::string appversion, std::string gfeversion, std::string rtspurl, bool framePacing,
-bool audioSync, bool hdrEnabled, std::string codecVideo) {
+bool audioSync, bool hdrEnabled, std::string codecVideo, std::string serverCodecSupportMode) {
   PostToJs("Setting stream width to: " + width);
   PostToJs("Setting stream height to: " + height);
   PostToJs("Setting stream fps to: " + fps);
@@ -192,6 +192,7 @@ bool audioSync, bool hdrEnabled, std::string codecVideo) {
   PostToJs("Setting audio syncing to: " + std::to_string(audioSync));
   PostToJs("Setting HDR to:" + std::to_string(hdrEnabled));
   PostToJs("Setting videoCodec: " + codecVideo);
+  PostToJs("Setting serverCodecSupportMode: " + serverCodecSupportMode);
 
   // Populate the stream configuration
   LiInitializeStreamConfiguration(&m_StreamConfig);
@@ -219,7 +220,7 @@ bool audioSync, bool hdrEnabled, std::string codecVideo) {
   m_FramePacingEnabled = framePacing;
   m_AudioSyncEnabled = audioSync;
   m_HdrEnabled = hdrEnabled;
-  m_supportedVideoFormats = stoi(codecVideo,0,16);
+  m_supportedVideoFormats = stoi(serverCodecSupportMode);
   
   // Initialize the rendering surface before starting the connection
   if (InitializeRenderingSurface(m_StreamConfig.width, m_StreamConfig.height)) {
@@ -318,10 +319,10 @@ int main(int argc, char** argv) {
 MessageResult startStream(std::string host, std::string width,
 std::string height, std::string fps, std::string bitrate, std::string rikey,
 std::string rikeyid, std::string appversion, std::string gfeversion, std::string rtspurl, bool framePacing,
-bool audioSync, bool hdrEnabled, std::string codecVideo) {
+bool audioSync, bool hdrEnabled, std::string codecVideo, std::string serverCodecSupportMode) {
   printf("%s host: %s w: %s h: %s\n", __func__, host.c_str(), width.c_str(), height.c_str());
   return g_Instance->StartStream(host, width, height, fps, bitrate, rikey,
-  rikeyid, appversion, gfeversion, rtspurl, framePacing, audioSync, hdrEnabled, codecVideo);
+  rikeyid, appversion, gfeversion, rtspurl, framePacing, audioSync, hdrEnabled, codecVideo, serverCodecSupportMode);
 }
 
 MessageResult stopStream() { return g_Instance->StopStream(); }

--- a/wasm/moonlight_wasm.hpp
+++ b/wasm/moonlight_wasm.hpp
@@ -61,7 +61,7 @@ public:
   MessageResult StartStream(std::string host, std::string width,
   std::string height, std::string fps, std::string bitrate, std::string rikey,
   std::string rikeyid, std::string appversion, std::string gfeversion, std::string rtspurl, bool framePacing,
-  bool audioSync, bool hdrEnabled, std::string codecVideo);
+  bool audioSync, bool hdrEnabled, std::string codecVideo, std::string serverCodecSupportMode);
   MessageResult StopStream();
 
   void STUN(int callbackId);
@@ -243,7 +243,8 @@ void openUrl(int callbackId, std::string url, emscripten::val ppk, bool binaryRe
 
 MessageResult startStream(std::string host, std::string width, std::string height, std::string fps,
 std::string bitrate, std::string rikey, std::string rikeyid, std::string appversion,
-std::string gfeversion, std::string rtspurl, bool framePacing, bool audioSync, bool hdrEnabled, std::string codecVideo);
+std::string gfeversion, std::string rtspurl, bool framePacing, bool audioSync, bool hdrEnabled, std::string codecVideo,
+std::string serverCodecSupportMode);
 
 MessageResult stopStream();
 

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -843,7 +843,7 @@ function startGame(host, appID) {
       }
 
       var frameRate = $('#selectFramerate').data('value').toString();
-	  var codecVideo = $('#selectCodecVideo').data('value').toString();
+      var codecVideo = $('#selectCodecVideo').data('value').toString();
       var optimize = $("#optimizeGamesSwitch").parent().hasClass('is-checked') ? 1 : 0;
       var streamWidth = $('#selectResolution').data('value').split(':')[0];
       var streamHeight = $('#selectResolution').data('value').split(':')[1];
@@ -894,11 +894,12 @@ function startGame(host, appID) {
             rikeyid.toString(),
             host.appVersion,
             "",
-			$root.find('sessionUrl0').text().trim(),
-			framePacingEnabled,
+            $root.find('sessionUrl0').text().trim(),
+            framePacingEnabled,
             audioSyncEnabled,
             hdrEnabled,
-            codecVideo		 
+            codecVideo,
+            host.serverCodecSupportMode		 
           ]);
         }, function(failedResumeApp) {
           console.error('%c[index.js, startGame]', 'color:green;', 'Failed to resume the app! Returned error was' + failedResumeApp);
@@ -936,11 +937,12 @@ function startGame(host, appID) {
           rikeyid.toString(),
           host.appVersion,
           "",
-		  $root.find('sessionUrl0').text().trim(),
+		      $root.find('sessionUrl0').text().trim(),
           framePacingEnabled,
           audioSyncEnabled,
           hdrEnabled,
-          codecVideo			  
+          codecVideo,
+          host.serverCodecSupportMode			  
         ]);
       }, function(failedLaunchApp) {
         console.error('%c[index.js, launchApp]', 'color: green;', 'Failed to launch app width id: ' + appID + '\nReturned error was: ' + failedLaunchApp);

--- a/wasm/wasmplayer.cpp
+++ b/wasm/wasmplayer.cpp
@@ -167,9 +167,9 @@ int height, int redrawRate, void* context, int drFlags) {
     } else if(videoFormat & VIDEO_FORMAT_H264) {
       mimetype = "video/mp4; codecs=\"avc1.64002A\"";  // h264 High Profile 4.2 mimeType
     } else if (videoFormat & VIDEO_FORMAT_AV1_MAIN8) {
-      mimetype = "video/mp4; codecs=\"av01.0.13M.08\"";  // AV1 Main Profile, level 2.0, Main tier, 8 bits
+      mimetype = "video/mp4; codecs=\"av01.0.13M.08\"";  // AV1 Main Profile, level 5.1, Main tier, 8 bits
     } else if (videoFormat & VIDEO_FORMAT_AV1_MAIN10) {
-      mimetype = "video/mp4; codecs=\"av01.0.13M.10\"";  // AV1 Main Profile, level 2.0, Main tier, 10 bits
+      mimetype = "video/mp4; codecs=\"av01.0.13M.10\"";  // AV1 Main Profile, level 5.1, Main tier, 10 bits
     }
     else {
       ClLogMessage("Cannot select mime type for videoFormat=0x%x\n", videoFormat);

--- a/wasm/wasmplayer.cpp
+++ b/wasm/wasmplayer.cpp
@@ -166,6 +166,10 @@ int height, int redrawRate, void* context, int drFlags) {
       mimetype = "video/mp4; codecs=\"hev1.1.6.L93.B0\"";  // h265 main mimeType
     } else if(videoFormat & VIDEO_FORMAT_H264) {
       mimetype = "video/mp4; codecs=\"avc1.64002A\"";  // h264 High Profile 4.2 mimeType
+    } else if (videoFormat & VIDEO_FORMAT_AV1_MAIN8) {
+      mimetype = "video/mp4; codecs=\"av01.0.13M.08\"";  // AV1 Main Profile, level 2.0, Main tier, 8 bits
+    } else if (videoFormat & VIDEO_FORMAT_AV1_MAIN10) {
+      mimetype = "video/mp4; codecs=\"av01.0.13M.10\"";  // AV1 Main Profile, level 2.0, Main tier, 10 bits
     }
     else {
       ClLogMessage("Cannot select mime type for videoFormat=0x%x\n", videoFormat);


### PR DESCRIPTION
# Add AV1 support

Changes proposed in this pull request:
- Fix server codec support checks to use `ServerCodecSupportMode` from server info
- Add AV1 8 bit and 10 bit as options

@OneLiberty 

Tested with QN90A and it seems to work