### PR TITLE
Fix the video codec negociation

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -72,10 +72,10 @@
 
             <ul class="codecVideoMenu mdl-menu mdl-menu--bottom-right mdl-js-menu mdl-js-ripple-effect" for="selectCodecVideo">
               <li class="mdl-menu__item" data-value=0x0001>H264</li>
-              <li class="mdl-menu__item" data-value=0x0100>HEVC</li>
-              <li class="mdl-menu__item" data-value=0x0200>HEVC Main10</li>
-              <li class="mdl-menu__item" data-value=0x1000>AV1</li>
-              <li class="mdl-menu__item" data-value=0x2000>AV1 Main10</li>
+              <li class="mdl-menu__item" data-value=0x0101>HEVC</li>
+              <li class="mdl-menu__item" data-value=0x0201>HEVC Main10</li>
+              <li class="mdl-menu__item" data-value=0x1201>AV1</li>
+              <li class="mdl-menu__item" data-value=0x2201>AV1 Main10</li>
 
 
             </ul>


### PR DESCRIPTION
Fix the video codec negociation between the server and Moonlight : If Moonlight is set to a video codec not supported by the server, it is now going to choose the best video codec available on the server (AV1 then HEVC then H264) instead of defaulting to H264.

fixes #35 